### PR TITLE
Allow to send the URI as parameter without having to use --uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ docker exec -it dolphie dolphie -h host.docker.internal -u root --ask-pass
 
 ## Usage
 ```
+usage: dolphie [--help] [-u USER] [-p PASSWORD] [--ask-pass] [-h HOST] [-P PORT] [-S SOCKET] [--uri URI] [-c CONFIG_FILE]
+               [-f HOST_CACHE_FILE] [-q QUICK_SWITCH_HOSTS_FILE] [-l LOGIN_PATH] [-r REFRESH_INTERVAL] [-H HEARTBEAT_TABLE]
+               [--ssl-mode SSL_MODE] [--ssl-ca SSL_CA] [--ssl-cert SSL_CERT] [--ssl-key SSL_KEY] [--hide-dashboard]
+               [--show-trxs-only] [--additional-columns] [--use-processlist] [-V]
+               [uri]
+
+Dolphie, an intuitive feature-rich top tool for monitoring MySQL in real time
+
+positional arguments:
+  uri                   Use a URI string for credentials - format: mysql://user:password@host:port 
+                        (port is optional with default 3306)
+
 options:
   --help                show this help message and exit
   -u USER, --user USER  Username for MySQL

--- a/dolphie/app.py
+++ b/dolphie/app.py
@@ -74,6 +74,17 @@ Environment variables support these options:
     )
 
     parser.add_argument(
+        "uri2", 
+        metavar='uri', 
+        type=str, 
+        nargs='?',
+        help=(
+                "Use a URI string for credentials - format: mysql://user:password@host:port (port is optional with"
+                " default 3306)"
+            )
+    )
+
+    parser.add_argument(
         "-u",
         "--user",
         dest="user",
@@ -301,6 +312,8 @@ Environment variables support these options:
             setattr(dolphie, option, parameter_options[option])
 
     # Lastly, parse URI if specified
+    if parameter_options["uri2"]:
+        parameter_options["uri"] = parameter_options["uri2"]
     if parameter_options["uri"]:
         parsed = urlparse(parameter_options["uri"])
         if parsed.scheme != "mysql":


### PR DESCRIPTION
like: 

`$ dolphie mysql://root:password@127.0.0.1`

This is to be more inline with the standard way to use it like MySQL Shell