### PR TITLE
chore: update license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "dolphie"
 version = "3.0.4"
+license = "GPL-3.0-or-later"
 description = "An intuitive feature-rich top tool for monitoring MySQL in real time"
 authors = ["Charles Thompson <01charles.t@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
👋 GPL-3.0 is deprecated by [SPDX](https://spdx.org/licenses/GPL-3.0), propose to declare GPL-3.0-or-later in the license field of pyproject.toml file. Thanks!

relates to https://github.com/Homebrew/homebrew-core/pull/140010