### PR TITLE
docs: add homebrew installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,30 @@ Requires Python 3.8+
 
 #### Using PyPi
 ```shell
-pip install dolphie
+$ pip install dolphie
 ```
 
 #### Using Poetry
 ```shell
-curl -sSL https://install.python-poetry.org | python3 -
+$ curl -sSL https://install.python-poetry.org | python3 -
 
-poetry install
+$ poetry install
+```
+
+### Using Homebrew
+
+If you are a [Homebrew](https://brew.sh/) user, can you install [dolphie](https://formulae.brew.sh/formula/dolphie) via
+
+```sh
+$ brew install dolphie
 ```
 
 #### Using Docker
-```
-docker pull ghcr.io/charles-001/dolphie:latest
-docker run -dit --name dolphie ghcr.io/charles-001/dolphie:latest
-docker exec -it dolphie dolphie -h host.docker.internal -u root --ask-pass
+
+```sh
+$ docker pull ghcr.io/charles-001/dolphie:latest
+$ docker run -dit --name dolphie ghcr.io/charles-001/dolphie:latest
+$ docker exec -it dolphie dolphie -h host.docker.internal -u root --ask-pass
 ```
 
 ## Usage


### PR DESCRIPTION
Update README to include a homebrew installation note.

```
$ brew install dolphie
==> Fetching dolphie
==> Downloading https://ghcr.io/v2/homebrew/core/dolphie/manifests/3.0.9
########################################################################### 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/dolphie/blobs/sha256:b7ce9adf02c6
########################################################################### 100.0%
==> Pouring dolphie--3.0.9.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/dolphie/3.0.9: 746 files, 4.9MB
```