### PR TITLE
Add Current/Instantaneous view of to events_statements_summary panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 dist/
 
 .idea
+.history

--- a/dolphie/Modules/PerformanceSchemaMetrics.py
+++ b/dolphie/Modules/PerformanceSchemaMetrics.py
@@ -17,7 +17,7 @@ class PerformanceSchemaMetrics:
             row[self.metric_key]: {
                 "event_name": row.get("EVENT_NAME"),
                 "metrics": {
-                    metric: {"total": value, "delta": 0}
+                    metric: {"total": value, "delta": 0, "delta_last_sample": 0}
                     for metric, value in row.items()
                     if isinstance(value, int) and metric not in self.ignore_int_columns
                 },
@@ -56,7 +56,7 @@ class PerformanceSchemaMetrics:
             if instance_name not in self.internal_data:
                 self.internal_data[instance_name] = {
                     "event_name": row.get("EVENT_NAME"),
-                    "metrics": {metric: {"total": value, "delta": 0} for metric, value in metrics.items()},
+                    "metrics": {metric: {"total": value, "delta": 0, "delta_last_sample": 0} for metric, value in metrics.items()},
                 }
 
             deltas_changed = False
@@ -71,6 +71,7 @@ class PerformanceSchemaMetrics:
                 metric_data["total"] = current_value
                 if delta > 0:
                     metric_data["delta"] += delta
+                    metric_data["delta_last_sample"] = delta
                     deltas_changed = True
 
                 if metric_data["delta"] > 0:
@@ -86,10 +87,11 @@ class PerformanceSchemaMetrics:
 
                     # Only add delta if it's greater than 0
                     delta = values["delta"] if values["delta"] > 0 else 0
+                    delta_last_sample = values["delta_last_sample"] if values["delta_last_sample"] > 0 else 0
 
                     # Only include the metric in filtered_data if it has a delta greater than 0
                     if delta > 0:
-                        self.filtered_data[instance_name][metric] = {"t": total, "d": delta}
+                        self.filtered_data[instance_name][metric] = {"t": total, "d": delta, "d_last_sample": delta_last_sample}
                     else:
                         self.filtered_data[instance_name][metric] = {"t": total}
 

--- a/dolphie/Modules/TabManager.py
+++ b/dolphie/Modules/TabManager.py
@@ -512,6 +512,7 @@ class TabManager:
                             [
                                 RadioButton("Delta since panel opened", id="statements_summarys_delta", value=True),
                                 RadioButton("Total since MySQL restart", id="statements_summary_total"),
+                                RadioButton("Delta since last sample", id="statements_summary_delta_last_sample"),
                             ]
                         ),
                         id="statements_summary_radio_set",

--- a/dolphie/Modules/TabManager.py
+++ b/dolphie/Modules/TabManager.py
@@ -511,8 +511,8 @@ class TabManager:
                         *(
                             [
                                 RadioButton("Delta since panel opened", id="statements_summarys_delta", value=True),
-                                RadioButton("Total since MySQL restart", id="statements_summary_total"),
                                 RadioButton("Delta since last sample", id="statements_summary_delta_last_sample"),
+                                RadioButton("Total since MySQL restart", id="statements_summary_total"),
                             ]
                         ),
                         id="statements_summary_radio_set",

--- a/dolphie/Panels/StatementsSummaryMetrics.py
+++ b/dolphie/Panels/StatementsSummaryMetrics.py
@@ -73,8 +73,10 @@ def create_panel(tab: Tab):
                 if isinstance(column_value, dict):
                     if tab.statements_summary_radio_set.pressed_button.id == "statements_summary_total":
                         column_value = column_value.get("t", 0)
-                    else:
+                    elif tab.statements_summary_radio_set.pressed_button.id == "statements_summarys_delta":
                         column_value = column_value.get("d", 0)
+                    else:
+                        column_value = column_value.get("d_last_sample", 0)
 
                 if column_name == "Query":
                     if tab.dolphie.show_statements_summary_query_digest_text_sample:


### PR DESCRIPTION
This PR adds the feature described in https://github.com/charles-001/dolphie/issues/94

tl;dr; in addition to total since MySQL restart and delta since it was opened, the events summary panel now shows
also the delta between the last sample and the current one as a current/instantaneous view of the statements on
mysql.