### PR TITLE
Add tab_title option to credential profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Environment variables support these options:
 	DOLPHIE_SSL_CERT
 	DOLPHIE_SSL_KEY
 	DOLPHIE_CONFIG
-	
+
 Dolphie's config supports these options under [dolphie] section:
 	(bool) tab_setup
 	(str) credential_profile

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ options:
   -h , --host           Hostname/IP address
   -P , --port           Port (socket has precedence)
   -S , --socket         Socket file
-  -c , --config-file    Dolphie's config file to use. Options are read from these files in the given order: ['/etc/dolphie.cnf', '/etc/dolphie/dolphie.cnf', '~/.dolphie.cnf']
+  -c , --config-file    Dolphie's config file to use, takes precedence over DOLPHIE_CONFIG environment variable. If neither is set, options are read from these files in the given order: ['/etc/dolphie.cnf', '/etc/dolphie/dolphie.cnf', '~/.dolphie.cnf']
   -m , --mycnf-file     MySQL config file path to use. This should use [client] section [default: ~/.my.cnf]
   -l , --login-path     Specify login path to use with mysql_config_editor's file ~/.mylogin.cnf for encrypted login credentials [default: client]
   -r , --refresh-interval
@@ -98,7 +98,7 @@ Order of precedence for methods that pass options to Dolphie:
 	1. Command-line
 	2. Credential profile (set by --cred-profile)
 	3. Environment variables
-	4. Dolphie's config (set by --config-file)
+	4. Dolphie's config (set by --config-file OR DOLPHIE_CONFIG)
 	5. ~/.mylogin.cnf (mysql_config_editor)
 	6. ~/.my.cnf (set by --mycnf-file)
 
@@ -145,7 +145,8 @@ Environment variables support these options:
 	DOLPHIE_SSL_CA
 	DOLPHIE_SSL_CERT
 	DOLPHIE_SSL_KEY
-
+	DOLPHIE_CONFIG
+	
 Dolphie's config supports these options under [dolphie] section:
 	(bool) tab_setup
 	(str) credential_profile

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following options are supported in credential profiles:
 	ssl_ca
 	ssl_cert
 	ssl_key
+	tab_title
 	mycnf_file
 	login_path
 

--- a/dolphie/Modules/ArgumentParser.py
+++ b/dolphie/Modules/ArgumentParser.py
@@ -30,6 +30,7 @@ class CredentialProfile:
     ssl_ca: str = None
     ssl_cert: str = None
     ssl_key: str = None
+    tab_title: str = None
 
 
 @dataclass
@@ -136,6 +137,7 @@ The following options are supported in credential profiles:
 \tssl_ca
 \tssl_cert
 \tssl_key
+\ttab_title
 \tmycnf_file
 \tlogin_path
 
@@ -767,7 +769,7 @@ Dolphie's config supports these options under [dolphie] section:
         ]
 
         # All options. mycnf_file and login_path are processed instead of directly set
-        supported_options = credential_profile_options + ["mycnf_file", "login_path"]
+        supported_options = credential_profile_options + ["tab_title", "mycnf_file", "login_path"]
 
         credential_name = section.split("credential_profile_")[1]
         credential = CredentialProfile(name=credential_name)
@@ -777,6 +779,9 @@ Dolphie's config supports these options under [dolphie] section:
 
             if key in credential_profile_options:
                 setattr(credential, key, value)
+                self.add_to_debug_options(f"cred profile setup - {credential_name}", key, value)
+            elif key == "tab_title":
+                credential.tab_title = value
                 self.add_to_debug_options(f"cred profile setup - {credential_name}", key, value)
             elif key == "mycnf_file":
                 if not os.path.isfile(value):

--- a/dolphie/Modules/ArgumentParser.py
+++ b/dolphie/Modules/ArgumentParser.py
@@ -120,7 +120,7 @@ Order of precedence for methods that pass options to Dolphie:
 \t1. Command-line
 \t2. Credential profile (set by --cred-profile)
 \t3. Environment variables
-\t4. Dolphie's config (set by --config-file)
+\t4. Dolphie's config (set by --config-file OR DOLPHIE_CONFIG)
 \t5. ~/.mylogin.cnf (mysql_config_editor)
 \t6. ~/.my.cnf (set by --mycnf-file)
 
@@ -169,6 +169,7 @@ Environment variables support these options:
 \tDOLPHIE_SSL_CA
 \tDOLPHIE_SSL_CERT
 \tDOLPHIE_SSL_KEY
+\tDOLPHIE_CONFIG
 
 Dolphie's config supports these options under [dolphie] section:
 \t{self.formatted_options}
@@ -255,7 +256,8 @@ Dolphie's config supports these options under [dolphie] section:
             dest="config_file",
             type=str,
             help=(
-                f"Dolphie's config file to use. Options are read from these files in the given order: "
+                f"Dolphie's config file to use, takes precedence over DOLPHIE_CONFIG environment variable. "
+                f"If neither is set, options are read from these files in the given order: "
                 f"{self.config.config_file}"
             ),
             metavar="",
@@ -537,6 +539,9 @@ Dolphie's config supports these options under [dolphie] section:
 
         if options["config_file"]:
             self.config.config_file = [options["config_file"]]
+        elif os.environ.get("DOLPHIE_CONFIG"):
+            self.config.config_file = [os.environ["DOLPHIE_CONFIG"]]
+            self.add_to_debug_options("environment", "config_file", os.environ["DOLPHIE_CONFIG"])
 
         # Loop through config files to find the supplied options
         for config_file in self.config.config_file:

--- a/dolphie/Modules/TabManager.py
+++ b/dolphie/Modules/TabManager.py
@@ -639,6 +639,13 @@ class TabManager:
                     config.socket = credential_profile_data.socket
                 if credential_profile_data.ssl:
                     config.ssl = credential_profile_data.ssl
+                if not tab.manual_tab_name and credential_profile_data.tab_title:
+                    tab.manual_tab_name = credential_profile_data.tab_title
+        elif config.credential_profile:
+            # When launched with -C alone, use the credential profile's tab_title if set
+            credential_profile_data = self.config.credential_profiles.get(config.credential_profile)
+            if credential_profile_data and credential_profile_data.tab_title:
+                tab.manual_tab_name = credential_profile_data.tab_title
 
         # Create a new Dolphie instance
         dolphie = Dolphie(config=config, app=self.app)


### PR DESCRIPTION
- Add a new `tab_title` option to credential profiles that sets the tab name when launching with that profile
- Applies both when used via host/host-group references (if not set) and when launched directly with `-C <profile>`
- Respects any manually-set tab name (won't override an existing `manual_tab_name`)