### PR TITLE
fix/feat: rolling window trim, correct graph timestamps, and configurable graph window

### DIFF
--- a/dolphie/Dolphie.py
+++ b/dolphie/Dolphie.py
@@ -40,6 +40,7 @@ class Dolphie:
         self.host_cache_file = config.host_cache_file
         self.tab_setup_file = config.tab_setup_file
         self.refresh_interval = config.refresh_interval
+        self.graph_window_minutes = config.graph_window_minutes
         self.show_trxs_only = config.show_trxs_only
         self.show_threads_with_concurrency_tickets = False
         self.show_additional_query_columns = config.show_additional_query_columns
@@ -72,7 +73,9 @@ class Dolphie:
         self.reset_runtime_variables()
 
     def reset_runtime_variables(self):
-        self.metric_manager = MetricManager.MetricManager(self.replay_file, self.daemon_mode)
+        self.metric_manager = MetricManager.MetricManager(
+            self.replay_file, self.daemon_mode, self.graph_window_minutes
+        )
         self.replica_manager = DataTypes.ReplicaManager()
 
         self.dolphie_start_time: datetime = datetime.now().astimezone()

--- a/dolphie/Modules/ArgumentParser.py
+++ b/dolphie/Modules/ArgumentParser.py
@@ -68,7 +68,7 @@ class Config:
     host_cache_file: str = field(default_factory=lambda: f"{os.path.expanduser('~')}/dolphie_host_cache")
     tab_setup_file: str = field(default_factory=lambda: f"{os.path.expanduser('~')}/dolphie_hosts")
     refresh_interval: int = 1
-    graph_window_minutes: int = 60
+    graph_window_minutes: int = 10
     heartbeat_table: str = None
     credential_profiles: dict[str, CredentialProfile] = field(default_factory=dict)
     tab_setup_available_hosts: list[str] = field(default_factory=list)

--- a/dolphie/Modules/ArgumentParser.py
+++ b/dolphie/Modules/ArgumentParser.py
@@ -68,6 +68,7 @@ class Config:
     host_cache_file: str = field(default_factory=lambda: f"{os.path.expanduser('~')}/dolphie_host_cache")
     tab_setup_file: str = field(default_factory=lambda: f"{os.path.expanduser('~')}/dolphie_hosts")
     refresh_interval: int = 1
+    graph_window_minutes: int = 60
     heartbeat_table: str = None
     credential_profiles: dict[str, CredentialProfile] = field(default_factory=dict)
     tab_setup_available_hosts: list[str] = field(default_factory=list)
@@ -292,6 +293,17 @@ Dolphie's config supports these options under [dolphie] section:
             help=(
                 "The time, in seconds, between each data collection and processing cycle "
                 f"[default: {self.config.refresh_interval}]"
+            ),
+            metavar="",
+        )
+        self.parser.add_argument(
+            "--graph-window-minutes",
+            dest="graph_window_minutes",
+            type=int,
+            help=(
+                "How many minutes of history to retain in the metric graphs. Older datetimes and "
+                "their metric values are trimmed on each refresh cycle. Set to 0 to disable trimming "
+                f"and accumulate all history [default: {self.config.graph_window_minutes}]"
             ),
             metavar="",
         )

--- a/dolphie/Modules/MetricManager.py
+++ b/dolphie/Modules/MetricManager.py
@@ -1120,8 +1120,9 @@ class MetricManager:
 
         self.add_metric_datetime()
 
-        if self.daemon_mode:
-            self.trim_datetimes_to_window(worker_start_time)
+        # Apply rolling window trim in TUI mode as well (previously daemon-only).
+        # Without this, graphs accumulate indefinitely in interactive sessions.
+        self.trim_datetimes_to_window(worker_start_time)
 
         self.initialized = True
 

--- a/dolphie/Modules/MetricManager.py
+++ b/dolphie/Modules/MetricManager.py
@@ -713,9 +713,12 @@ class MetricManager:
     """Manages the state, collection, and processing of all metrics."""
 
     DATETIME_FORMAT = "%d/%m/%y %H:%M:%S"
-    DEFAULT_ROLLING_WINDOW_MINUTES = 60
-    # Backward-compatible alias; ReplayManager references this name as a default.
-    ROLLING_WINDOW_MINUTES = DEFAULT_ROLLING_WINDOW_MINUTES
+    # Default for the instance-level rolling_window_minutes (TUI graph trim).
+    # Configurable per-run via --graph-window-minutes.
+    DEFAULT_ROLLING_WINDOW_MINUTES = 10
+    # Replay rebuild window used by ReplayManager.fetch_delta_metrics_for_window.
+    # Independent from the TUI graph window above.
+    ROLLING_WINDOW_MINUTES = 10
 
     def __init__(self, replay_file: str, daemon_mode: bool = False, rolling_window_minutes: int = None):
         """Initialize the MetricManager.

--- a/dolphie/Modules/MetricManager.py
+++ b/dolphie/Modules/MetricManager.py
@@ -6,7 +6,7 @@ import dataclasses
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Union
 
@@ -1141,7 +1141,12 @@ class MetricManager:
     def add_metric_datetime(self):
         """Adds the current worker timestamp to the global datetime list."""
         if self.initialized and not self.replay_file and self.worker_start_time:
-            self.datetimes.append(self.worker_start_time.strftime(self.DATETIME_FORMAT))
+            # plotext parses these strings as UTC and then renders them in the
+            # local timezone. Store the timestamps as UTC so the rendered
+            # X-axis labels match the host's wall clock time.
+            self.datetimes.append(
+                self.worker_start_time.astimezone(timezone.utc).strftime(self.DATETIME_FORMAT)
+            )
 
     def get_metric_source_data(self, metric_source: MetricSource) -> dict[str, int] | None:
         """Retrieves the raw data dictionary for a given MetricSource."""
@@ -1324,7 +1329,11 @@ class MetricManager:
         if not self.datetimes:
             return False
 
-        threshold = reference_time.replace(tzinfo=None) - timedelta(minutes=self.ROLLING_WINDOW_MINUTES)
+        # datetimes are stored as UTC (see add_metric_datetime); compare against
+        # reference_time converted to UTC to keep the window boundary consistent.
+        threshold = reference_time.astimezone(timezone.utc).replace(tzinfo=None) - timedelta(
+            minutes=self.ROLLING_WINDOW_MINUTES
+        )
         trimmed = False
 
         while self.datetimes:

--- a/dolphie/Modules/MetricManager.py
+++ b/dolphie/Modules/MetricManager.py
@@ -713,18 +713,26 @@ class MetricManager:
     """Manages the state, collection, and processing of all metrics."""
 
     DATETIME_FORMAT = "%d/%m/%y %H:%M:%S"
-    ROLLING_WINDOW_MINUTES = 10
+    DEFAULT_ROLLING_WINDOW_MINUTES = 60
+    # Backward-compatible alias; ReplayManager references this name as a default.
+    ROLLING_WINDOW_MINUTES = DEFAULT_ROLLING_WINDOW_MINUTES
 
-    def __init__(self, replay_file: str, daemon_mode: bool = False):
+    def __init__(self, replay_file: str, daemon_mode: bool = False, rolling_window_minutes: int = None):
         """Initialize the MetricManager.
 
         Args:
             replay_file: Path to a replay file, if one is being used.
             daemon_mode: True if running in daemon mode (trims old data).
+            rolling_window_minutes: How many minutes of history to keep in graph
+                data. 0 disables trimming (accumulate forever). None falls back
+                to DEFAULT_ROLLING_WINDOW_MINUTES.
         """
         self.connection_source = ConnectionSource.mysql
         self.replay_file = replay_file
         self.daemon_mode = daemon_mode
+        self.rolling_window_minutes = (
+            rolling_window_minutes if rolling_window_minutes is not None else self.DEFAULT_ROLLING_WINDOW_MINUTES
+        )
 
         # Attributes populated by refresh_data
         self.worker_start_time: datetime | None = None
@@ -1122,7 +1130,9 @@ class MetricManager:
 
         # Apply rolling window trim in TUI mode as well (previously daemon-only).
         # Without this, graphs accumulate indefinitely in interactive sessions.
-        self.trim_datetimes_to_window(worker_start_time)
+        # rolling_window_minutes <= 0 disables trimming.
+        if self.rolling_window_minutes > 0:
+            self.trim_datetimes_to_window(worker_start_time)
 
         self.initialized = True
 
@@ -1332,7 +1342,7 @@ class MetricManager:
         # datetimes are stored as UTC (see add_metric_datetime); compare against
         # reference_time converted to UTC to keep the window boundary consistent.
         threshold = reference_time.astimezone(timezone.utc).replace(tzinfo=None) - timedelta(
-            minutes=self.ROLLING_WINDOW_MINUTES
+            minutes=self.rolling_window_minutes
         )
         trimmed = False
 


### PR DESCRIPTION
## Summary

Three small changes to the metric graphs panel that build on each other:

1. **Apply the rolling window trim in TUI mode as well** (previously daemon-only). Interactive sessions otherwise accumulate datetimes + metric values indefinitely.
2. **Render graph X-axis labels in the host's local timezone**. plotext interprets the supplied datetime strings as UTC and re-renders them in the host's local timezone, so handing it `strftime` output of a tz-aware *local* datetime makes the labels drift by the local UTC offset (e.g. +9h on KST hosts).
3. **Make the rolling window duration configurable** via a new `--graph-window-minutes` option (and matching `graph_window_minutes` config-file key). Default changed from the previous hardcoded 10 to **60 minutes**. Passing `0` disables trimming and accumulates all history.

All three touch `dolphie/Modules/MetricManager.py`. (3) additionally touches `dolphie/Dolphie.py` and `dolphie/Modules/ArgumentParser.py` to plumb the option through.

## Demo
<img width="1280" height="386" alt="dolphie_graph_move" src="https://github.com/user-attachments/assets/f7c8248f-43fb-457a-b87e-b16434a5bee3" />

## Background

### 1. Trim was daemon-only

`update_metrics()` previously had:

```python
if self.daemon_mode:
    self.trim_datetimes_to_window(worker_start_time)
```

so `ROLLING_WINDOW_MINUTES` (10) never bounded interactive sessions. After running dolphie for a while, the graphs panel kept growing horizontally without an upper bound on history.

### 2. Graph X-axis labels off by the host UTC offset

`add_metric_datetime()` writes the local wall-clock string:

```python
self.datetimes.append(self.worker_start_time.strftime(self.DATETIME_FORMAT))
```

`worker_start_time` is `datetime.now().astimezone()` (timezone-aware, local). `strftime("%d/%m/%y %H:%M:%S")` produces the local wall-clock string but drops tz info.

plotext (5.3.2) then **parses that string as UTC and re-renders it in the host's local timezone** when laying out the date axis. On a KST host, a 17:46:45 KST sample is shown on the axis as the next day 02:46:45.

Empirical reproduction with the same plotext version dolphie ships with:

| Input (string fed to plotext) | Axis label on a KST host |
|---|---|
| KST `astimezone()` wall-clock `21/05/26 17:46:45` | `22/05/26 02:46:45` (+9h) |
| UTC `astimezone(UTC)` wall-clock `21/05/26 08:46:45` | `21/05/26 17:46:45` ✓ |
| Naive `datetime.now()` `21/05/26 17:46:45` | `22/05/26 02:46:45` (+9h) |

So we just need to feed plotext UTC strings — its own tz logic then produces the correct local labels.

### 3. Rolling window duration was a hidden constant

`ROLLING_WINDOW_MINUTES = 10` was a class attribute on `MetricManager` and not exposed to users. Even with (1) in place, operators frequently want a longer history window (30 / 60 minutes) without forking the code.

## Fix

### Timestamp normalization (commits 1 & 2)

Convert `worker_start_time` to UTC before formatting, and compare the trim window threshold against UTC as well (so the rolling window boundary lines up with the stored UTC timestamps):

```diff
- self.datetimes.append(self.worker_start_time.strftime(self.DATETIME_FORMAT))
+ self.datetimes.append(
+     self.worker_start_time.astimezone(timezone.utc).strftime(self.DATETIME_FORMAT)
+ )
```

```diff
- threshold = reference_time.replace(tzinfo=None) - timedelta(minutes=self.ROLLING_WINDOW_MINUTES)
+ threshold = reference_time.astimezone(timezone.utc).replace(tzinfo=None) - timedelta(
+     minutes=self.rolling_window_minutes
+ )
```

### Configurable window (commit 3)

New CLI option / config key:

```
--graph-window-minutes <N>     # CLI
graph_window_minutes = <N>     # [dolphie] section of dolphie.cnf
```

Default is `60`. `0` disables trimming entirely (accumulate forever — matches the historical pre-trim behavior in TUI mode, but is now explicit).

`MetricManager.ROLLING_WINDOW_MINUTES` is preserved as a class attribute alias of `DEFAULT_ROLLING_WINDOW_MINUTES` because `ReplayManager` references it as a default argument value. Removing it would break that import path.

## Compatibility

- The timezone fix is host-tz agnostic. `astimezone(timezone.utc)` is a no-op for UTC hosts and correctly handles DST hosts.
- dolphie's existing behavior of using host wall-clock time for the graph axis is preserved — no DB `time_zone` is consulted (that was already the case).
- `MetricManager.ROLLING_WINDOW_MINUTES` is kept as a backward-compatible class attribute alias, so `ReplayManager`'s `window_minutes: int = MetricManager.MetricManager.ROLLING_WINDOW_MINUTES` default still resolves.
- Replay path is otherwise untouched.

## Verification

- KST host (Asia/Seoul, `+09:00`): axis labels match wall clock to the second after the fix.
- Manual reproduction with each of the three input forms above against plotext 5.3.2 to confirm the UTC-input case is what plotext expects.
- `dolphie --help` shows the new option with `[default: 60]`.
- `MetricManager(None)`, `MetricManager(None, False, 5)`, `MetricManager(None, False, 0)` all initialize correctly; alias `MetricManager.ROLLING_WINDOW_MINUTES` still resolves so `ReplayManager` imports cleanly.

## Commits

- `fix: apply rolling window trim in tui mode`
- `fix: render graph timestamps in host local timezone`
- `feat: add --graph-window-minutes option (default 60)`
