### PR TITLE
Add Repository link on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ license = "GPL-3.0-or-later"
 description = "Your single pane of glass for real-time analytics into MySQL/MariaDB & ProxySQL"
 authors = ["Charles Thompson <01charles.t@gmail.com>"]
 readme = "README.md"
+[tool.poetry.urls]
+Repository = "https://github.com/charles-001/dolphie"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Make it so that https://pypi.org/project/dolphie/ will link back to the repository.